### PR TITLE
Chord inversion progression bug

### DIFF
--- a/webMidiConductor/musicConductorCtrl.js
+++ b/webMidiConductor/musicConductorCtrl.js
@@ -306,7 +306,6 @@ function isChordProgression() {
             var lastScaleDegreeChordPlayedASC = musicConductor.scaleRule.scaleDegreeByLetterASC.get(chord.letter) + ' ' + chord.type;
             var lastScaleDegreeChordPlayedDESC = musicConductor.scaleRule.scaleDegreeByLetterDESC.get(chord.letter) + ' ' + chord.type;
             if(chordProgressionMap.has(lastScaleDegreeChordPlayedASC) || chordProgressionMap.has(lastScaleDegreeChordPlayedDESC)) {
-                // lastChordPlayed = chord;
                 lastChordsPlayed.add(chord);
             }
         }
@@ -318,7 +317,6 @@ function isChordProgression() {
             var currentScaleDegreeChordPlayedASC = musicConductor.scaleRule.scaleDegreeByLetterASC.get(chord.letter) + ' ' + chord.type;
             var currentScaleDegreeChordPlayedDESC = musicConductor.scaleRule.scaleDegreeByLetterDESC.get(chord.letter) + ' ' + chord.type;
             if(chordProgressionMap.has(currentScaleDegreeChordPlayedASC) || chordProgressionMap.has(currentScaleDegreeChordPlayedDESC)) {
-                // currentChordPlaying = chord;
                 currentChordsPlaying.add(chord);
             }
         }
@@ -351,7 +349,6 @@ var musicConductor = {
     lastTimeWhenNoteInScalePlayedInMillis : 0,
     chordsPlaying : [],
     lastChordsPlayed : new Set(),
-    currentChordPlaying : undefined,
     currentChordsPlaying : new Set(),
     chordProgressionType : 'Major',
     chordProgressionsPlayedCount : 0,

--- a/webMidiConductor/musicConductorCtrl.js
+++ b/webMidiConductor/musicConductorCtrl.js
@@ -299,38 +299,48 @@ function isChordProgression() {
     if(chordProgressionMap == undefined || chordProgressionMap.size <= 0) {
         return false;
     }
-    var lastChordPlayed;
+
+    var lastChordsPlayed = new Set();
     for (const chord of musicConductor.lastChordsPlayed) {
         if(musicConductor.scaleRule.isInScaleAscOrDesc(chord.letter)) {
             var lastScaleDegreeChordPlayedASC = musicConductor.scaleRule.scaleDegreeByLetterASC.get(chord.letter) + ' ' + chord.type;
             var lastScaleDegreeChordPlayedDESC = musicConductor.scaleRule.scaleDegreeByLetterDESC.get(chord.letter) + ' ' + chord.type;
             if(chordProgressionMap.has(lastScaleDegreeChordPlayedASC) || chordProgressionMap.has(lastScaleDegreeChordPlayedDESC)) {
-                lastChordPlayed = chord;
+                // lastChordPlayed = chord;
+                lastChordsPlayed.add(chord);
             }
         }
     }
-    var currentChordPlaying;
+    
+    var currentChordsPlaying = new Set();
     for (const chord of musicConductor.currentChordsPlaying) {
         if(musicConductor.scaleRule.isInScaleAscOrDesc(chord.letter)) {
             var currentScaleDegreeChordPlayedASC = musicConductor.scaleRule.scaleDegreeByLetterASC.get(chord.letter) + ' ' + chord.type;
             var currentScaleDegreeChordPlayedDESC = musicConductor.scaleRule.scaleDegreeByLetterDESC.get(chord.letter) + ' ' + chord.type;
             if(chordProgressionMap.has(currentScaleDegreeChordPlayedASC) || chordProgressionMap.has(currentScaleDegreeChordPlayedDESC)) {
-                currentChordPlaying = chord;
+                // currentChordPlaying = chord;
+                currentChordsPlaying.add(chord);
             }
         }
     }
-
-    //TODO handle situation when there are multiple chords inversionally related that are qualify as a potential chord progression... try all permutations and return on first success.
-    
-    if(lastChordPlayed != undefined && currentChordPlaying != undefined && lastChordPlayed.name != currentChordPlaying.name) {
-        // var chordProgressionMap = new Map();
-        var lastScaleDegreeChordPlayedASC = musicConductor.scaleRule.scaleDegreeByLetterASC.get(lastChordPlayed.letter) + ' ' + lastChordPlayed.type;
-        var currentScaleDegreeChordPlayedASC = musicConductor.scaleRule.scaleDegreeByLetterASC.get(currentChordPlaying.letter) + ' ' + currentChordPlaying.type;
-        var lastScaleDegreeChordPlayedDESC = musicConductor.scaleRule.scaleDegreeByLetterDESC.get(lastChordPlayed.letter) + ' ' + lastChordPlayed.type;
-        var currentScaleDegreeChordPlayedDESC = musicConductor.scaleRule.scaleDegreeByLetterDESC.get(currentChordPlaying.letter) + ' ' + currentChordPlaying.type;
-        return (chordProgressionMap != undefined && chordProgressionMap.size > 0 && ((chordProgressionMap.has(lastScaleDegreeChordPlayedASC) && chordProgressionMap.get(lastScaleDegreeChordPlayedASC).has(currentScaleDegreeChordPlayedASC)) || (chordProgressionMap.has(lastScaleDegreeChordPlayedDESC) && chordProgressionMap.get(lastScaleDegreeChordPlayedDESC).has(currentScaleDegreeChordPlayedDESC))));
+    //handle situation when there are multiple chords inversionally related that have a scale degree chord type in the chord progression map... try all permutations and break out of loops on first success.
+    var isChordProgression = false;
+    if(lastChordsPlayed.size > 0 && currentChordsPlaying.size > 0) {
+        for(const lastChordPlayed of lastChordsPlayed) {
+            for(const currentChordPlaying of currentChordsPlaying) {
+                if(lastChordPlayed != undefined && currentChordPlaying != undefined && lastChordPlayed.name != currentChordPlaying.name) {
+                    var lastScaleDegreeChordPlayedASC = musicConductor.scaleRule.scaleDegreeByLetterASC.get(lastChordPlayed.letter) + ' ' + lastChordPlayed.type;
+                    var currentScaleDegreeChordPlayedASC = musicConductor.scaleRule.scaleDegreeByLetterASC.get(currentChordPlaying.letter) + ' ' + currentChordPlaying.type;
+                    var lastScaleDegreeChordPlayedDESC = musicConductor.scaleRule.scaleDegreeByLetterDESC.get(lastChordPlayed.letter) + ' ' + lastChordPlayed.type;
+                    var currentScaleDegreeChordPlayedDESC = musicConductor.scaleRule.scaleDegreeByLetterDESC.get(currentChordPlaying.letter) + ' ' + currentChordPlaying.type;
+                    isChordProgression = (chordProgressionMap != undefined && chordProgressionMap.size > 0 && ((chordProgressionMap.has(lastScaleDegreeChordPlayedASC) && chordProgressionMap.get(lastScaleDegreeChordPlayedASC).has(currentScaleDegreeChordPlayedASC)) || (chordProgressionMap.has(lastScaleDegreeChordPlayedDESC) && chordProgressionMap.get(lastScaleDegreeChordPlayedDESC).has(currentScaleDegreeChordPlayedDESC))));
+                }
+                if(isChordProgression) break;
+            }
+            if(isChordProgression) break;
+        }
     }
-    return false;
+    return isChordProgression;
 }
 
 var musicConductor = {

--- a/webMidiConductor/musicConductorCtrl.js
+++ b/webMidiConductor/musicConductorCtrl.js
@@ -293,6 +293,8 @@ function changeKeyAndScale(key, scale) {
  * @returns true or false
  */
 function isChordProgression() {
+    
+    
     if(musicConductor.lastChordPlayed != undefined && musicConductor.currentChordPlaying != undefined && musicConductor.lastChordPlayed.name != musicConductor.currentChordPlaying.name && musicConductor.scaleRule.isInScaleAscOrDesc(musicConductor.currentChordPlaying.letter) && musicConductor.scaleRule.isInScaleAscOrDesc(musicConductor.lastChordPlayed.letter)) {
         var chordProgressionMap = new Map();
         var lastScaleDegreeChordPlayedASC = musicConductor.scaleRule.scaleDegreeByLetterASC.get(musicConductor.lastChordPlayed.letter) + ' ' + musicConductor.lastChordPlayed.type;
@@ -313,7 +315,9 @@ var musicConductor = {
     lastTimeWhenNoteInScalePlayedInMillis : 0,
     chordsPlaying : [],
     lastChordPlayed : undefined,
+    lastChordsPlayed : new Set(),
     currentChordPlaying : undefined,
+    currentChordsPlaying : new Set(),
     chordProgressionType : 'Major',
     chordProgressionsPlayedCount : 0,
     maxMillisNoChordProgCountReset : 5000,
@@ -325,7 +329,11 @@ var musicConductor = {
  */
 function setMusicalPerformanceString() {
     if(musicConductor.chordsPlaying.length > 0) {
-        musicConductor.lastChordPlayed = new ChordInstance(musicConductor.chordsPlaying[musicConductor.chordsPlaying.length - 1]);
+        //musicConductor.lastChordPlayed = new ChordInstance(musicConductor.chordsPlaying[musicConductor.chordsPlaying.length - 1]);
+        musicConductor.lastChordsPlayed.clear();
+        musicConductor.chordsPlaying.forEach(chordName => musicConductor.lastChordsPlayed.add(new ChordInstance(chordName)));
+        // console.log('lastChordsPlayed: ');
+        // musicConductor.lastChordsPlayed.forEach(chordName => console.log(chordName));
     }
     musicConductor.chordsPlaying = [];
     //lazy load scale degree letters ascending and descending
@@ -357,6 +365,7 @@ function setMusicalPerformanceString() {
     var liveAudioInputEnabled = liveAudioInputEnabled || false;
     if(!liveAudioInputEnabled) {
         var chordsPlaying = [];
+        musicConductor.currentChordsPlaying.clear();
         for(chordName of chordLetterSetByChordName.keys()) {
             var oneChordLetterSet = chordLetterSetByChordName.get(chordName);
             if(oneChordLetterSet.size <= lettersPlaying.size) {
@@ -368,7 +377,8 @@ function setMusicalPerformanceString() {
                 }
                 if(isMatch) {
                     chordsPlaying.push(chordName);
-                    musicConductor.currentChordPlaying = new ChordInstance(chordName);
+                    //musicConductor.currentChordPlaying = new ChordInstance(chordName);
+                    musicConductor.currentChordsPlaying.add(new ChordInstance(chordName));
                 }
             }
         }
@@ -389,6 +399,7 @@ function setMusicalPerformanceString() {
     }
 }
 
+//Ideally set the delay to 100 ms to ensure precision, but leaving delay up to callter
 var musicPerformanceTimerVar;
 function switchOnOffMusicalPerformance(delay) {
     if(!musicPerformanceTimerVar) {


### PR DESCRIPTION
* Handling scenario when chords currently playing contains inversionally equivalent chords and the incorrect chord that is not in the scale gets evaluated for a chord progression.
* Handling scenario where inversionally equivalent chords in the chords currently playing collection have root notes in the context scale with the appropriate chord type, so isChordProgression() function was enhanced to check each permutation of last chords and current chords playing to determine if any of them qualify for a valid chord progression. 