### PR TITLE
feat: Dominant 7th Blues Chord Progression

### DIFF
--- a/webMidiConductor/midiChlorianController.js
+++ b/webMidiConductor/midiChlorianController.js
@@ -35,6 +35,7 @@ const CHORD_PROGRESSION_TYPES = {
     MAJOR : 'Major',
     MINOR : 'Minor',
     HARMONIC_MINOR : 'Harmonic Minor',
+    DOMINANT_7TH_BLUES : 'Dominant 7th Blues',
     CUSTOM: 'Custom'
 }
 Object.freeze(CHORD_PROGRESSION_TYPES);

--- a/webMidiConductor/musicConductorCtrl.js
+++ b/webMidiConductor/musicConductorCtrl.js
@@ -40,6 +40,7 @@ for (let key in CHORDS) {
 //Collection of CHORD_PROGRESSION_TYPES (defined in midiChlorianController): Major, Minor, Custom, etc.
 let chordProgressionMapByType = new Map();
 
+
 //MAJOR Chord Progression Map
 let majorKeyChordProgressionMap = new Map();
 majorKeyChordProgressionMap.set(chordTypeDegrees.get(CHORDS.MAJOR_TRIAD)[1], (new Set()).add(chordTypeDegrees.get(CHORDS.MINOR_TRIAD)[2]).add(chordTypeDegrees.get(CHORDS.MINOR_TRIAD)[3]).add(chordTypeDegrees.get(CHORDS.MAJOR_TRIAD)[4]).add(chordTypeDegrees.get(CHORDS.MAJOR_TRIAD)[5]).add(chordTypeDegrees.get(CHORDS.MINOR_TRIAD)[6]).add(chordTypeDegrees.get(CHORDS.DIMINISHED_TRIAD)[7]));
@@ -70,6 +71,7 @@ majorKeyChordProgressionMap.set(chordTypeDegrees.get(CHORDS.DIMINISHED_TRIAD)[7]
 majorKeyChordProgressionMap.set(chordTypeDegrees.get(CHORDS.MINOR_7TH_FLAT_5)[7], (new Set()).add(chordTypeDegrees.get(CHORDS.MAJOR_7TH)[1]));
 
 chordProgressionMapByType.set(CHORD_PROGRESSION_TYPES.MAJOR,majorKeyChordProgressionMap);
+
 
 //GAP ALERT!!!: With the minor key, the 6th and 7th scale degrees are variable when going up or down the scale, so the 6th and 7th chords should be determined if the current bar being played has it's pitch arching up or down. This scrutiny is being left out for the time being, so a decending or ascending only minor chord may be declared a valid chord progression regardless of the current bar's melodic contour.
 //TODO determine 7th chord progressions for "rare" minor key chord progressions  
@@ -116,6 +118,7 @@ minorKeyChordProgressionMap.set(chordTypeDegrees.get(CHORDS.DIMINISHED_7TH)[7], 
 
 chordProgressionMapByType.set(CHORD_PROGRESSION_TYPES.MINOR,minorKeyChordProgressionMap);
 
+
 //harmonic minor chord progression
 let harmonicMinorChordProgressionMap = new Map();
 harmonicMinorChordProgressionMap.set(chordTypeDegrees.get(CHORDS.MINOR_TRIAD)[1], (new Set()).add(chordTypeDegrees.get(CHORDS.DIMINISHED_TRIAD)[2]).add(chordTypeDegrees.get(CHORDS.AUGMENTED_TRIAD)[3]).add(chordTypeDegrees.get(CHORDS.MINOR_TRIAD)[4]).add(chordTypeDegrees.get(CHORDS.MAJOR_TRIAD)[5]).add(chordTypeDegrees.get(CHORDS.MAJOR_TRIAD)[6]).add(chordTypeDegrees.get(CHORDS.DIMINISHED_TRIAD)[7]));
@@ -146,8 +149,21 @@ harmonicMinorChordProgressionMap.set(chordTypeDegrees.get(CHORDS.DIMINISHED_TRIA
 
 harmonicMinorChordProgressionMap.set(chordTypeDegrees.get(CHORDS.DIMINISHED_7TH)[7], (new Set()).add(chordTypeDegrees.get(CHORDS.MINOR_MAJOR_7TH)[1]));
 
-
 chordProgressionMapByType.set(CHORD_PROGRESSION_TYPES.HARMONIC_MINOR, harmonicMinorChordProgressionMap);
+
+
+//Dominant 7th Blues Chord Progression
+let dominant7thBluesProgressionMap = new Map();
+dominant7thBluesProgressionMap.set(chordTypeDegrees.get(CHORDS.DOMINANT_7TH)[1], (new Set()).add(chordTypeDegrees.get(CHORDS.DOMINANT_7TH)[4]).add(chordTypeDegrees.get(CHORDS.DOMINANT_7TH)[5]));
+
+dominant7thBluesProgressionMap.set(chordTypeDegrees.get(CHORDS.DOMINANT_7TH)[3], (new Set()).add(chordTypeDegrees.get(CHORDS.DOMINANT_7TH)[1]));
+
+dominant7thBluesProgressionMap.set(chordTypeDegrees.get(CHORDS.DOMINANT_7TH)[4], (new Set()).add(chordTypeDegrees.get(CHORDS.DOMINANT_7TH)[1]));
+
+dominant7thBluesProgressionMap.set(chordTypeDegrees.get(CHORDS.DOMINANT_7TH)[5], (new Set()).add(chordTypeDegrees.get(CHORDS.DOMINANT_7TH)[1]).add(chordTypeDegrees.get(CHORDS.DOMINANT_7TH)[4]));
+
+chordProgressionMapByType.set(CHORD_PROGRESSION_TYPES.DOMINANT_7TH_BLUES, dominant7thBluesProgressionMap);
+
 
 //Client is free to set values as they please to this map
 let customChordProgressionMap = new Map();


### PR DESCRIPTION
* Created standard I7, IV7, V7 chord progression map.
* Introduced III7 as an alternative to IV7 because the 3rd scale degree in the blues minor scale correlates to the 4th scale degree in the key's major scale, and the blues chords are commonly played using dominant 7th chords from the key's major scale. The 1st and 5th degrees in the minor blues scale match the notes in the major scale. 
   * I7 -> IV7, V7
   * III7 -> I7
   * IV7 -> I7
   * V7 -> I7, IV7 
   * The scale played is typically the blues minor scale which has the algorithm: 321132. In the C blues minor, the keys are C Eb F F# G Bb C.
   * The major scale algorithm is 2212221. In C Major scale, the keys are C D E F G A B C
   * Therefor a F7 in C blues minor is related to the 3rd degree; not the 4th. G7 is related to the 5th.
   * PROOF: Is III7 in minor blues a reliable substitute for IV7 in the major scale?
      * 3rd degree in minor blues is 3+2=5 steps away from root
      * 4th degree in major scale is 2+2+1 = 5 steps away from root
   * PROOF: Is V7 the same in the minor blues an major scale?
      * 5th degree in minor blues scale is 3+2+1+1=7 steps away from root
      * 5th degree in major scale is 2+2+1+2=7 steps away from root